### PR TITLE
升级至 actions/checkout@v3 使用 Node 16

### DIFF
--- a/.github/workflows/quarto-book-netlify.yaml
+++ b/.github/workflows/quarto-book-netlify.yaml
@@ -27,7 +27,7 @@ jobs:
       CMDSTAN: "/opt/cmdstan/cmdstan-2.29.2"
       CMDSTANR_NO_VER_CHECK: true
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install Quarto
         uses: quarto-dev/quarto-actions/setup@v2


### PR DESCRIPTION
升级至 actions/checkout@v3 使用 Node 16，Node 12 已经 deprecation，详见 https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/
