### PR TITLE
升级 Quarto 至预发布版

### DIFF
--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -14,7 +14,7 @@ jobs:
       RETICULATE_PYTHON_ENV: "/opt/.virtualenvs/r-tensorflow"
       CMDSTAN_VERSION: "2.31.0"
       CMDSTAN: "/opt/cmdstan/cmdstan-2.31.0"
-      QUARTO_VERSION: "1.2.280"
+      QUARTO_VERSION: "1.3.242"
     steps:
       - 
         name: Checkout

--- a/.github/workflows/quarto-book-ubuntu.yaml
+++ b/.github/workflows/quarto-book-ubuntu.yaml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: r-lib/actions/setup-pandoc@v2
         with:
-          pandoc-version: '2.19.2'
+          pandoc-version: '3.1'
 
       - name: Install Quarto
         uses: quarto-dev/quarto-actions/setup@v2

--- a/.github/workflows/quarto-book-ubuntu.yaml
+++ b/.github/workflows/quarto-book-ubuntu.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Install Quarto
         uses: quarto-dev/quarto-actions/setup@v2
         with:
-          version: 1.2.280
+          version: pre-release
       - run: |
           quarto --version
           quarto pandoc --version

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -100,10 +100,15 @@ format:
   pdf:
     documentclass: book
     include-in-header: preamble.tex
-    classoption: [UTF8,twoside,openany,table]
+    classoption: 
+      - UTF8
+      - twoside
+      - openany
+      - table
     keep-tex: true
     lof: true
     lot: true
+    mathspec: true
     geometry:
       - tmargin=2.5cm
       - bmargin=2.5cm

--- a/preamble.tex
+++ b/preamble.tex
@@ -7,7 +7,6 @@
 \RecustomVerbatimEnvironment{Highlighting}{Verbatim}{commandchars=\\\{\},formatcom=\xeCJKVerbAddon}
 
 \usepackage{animate}
-% \bm
-% \usepackage{bm}
-\def\bm#1{{\boldsymbol #1}}
+\usepackage{bm} % \bm
+% \def\bm#1{{\boldsymbol #1}}
 \frontmatter


### PR DESCRIPTION
因 Quarto 预发布版修复了两个重要的问题 [quarto pandoc --version](https://github.com/XiangyunHuang/data-analysis-in-action/issues/24)，一个是数学公式 `\bm` 冲突，一个是附录名称汉化

**注意**

以后写作过程中，如果没有遇到 Quarto 问题，就不升级了。